### PR TITLE
Argumentos a los controles BeforeSave AfterSave y a los eventos de page beforeSave y afterSave

### DIFF
--- a/app7/generic.js
+++ b/app7/generic.js
@@ -1675,12 +1675,14 @@ async function saveDoc(exitOnSuccess) {
     });
 
     try {
+        var args = [];
+        args.push(exitOnSuccess);
         // Evento beforeSave
         $page[0].dispatchEvent(new CustomEvent('beforeSave'));
 
         // Control Event BeforeSave
         var ev = getEvent('BeforeSave');
-        if (ev) await evalCode(ev);
+        if (ev) await evalCode(ev, args);
 
         await doc.save();
         docJson = doc.toJSON();
@@ -1705,7 +1707,7 @@ async function saveDoc(exitOnSuccess) {
 
             // Control Event AfterSave
             var ev = getEvent('AfterSave');
-            if (ev) await evalCode(ev);
+            if (ev) await evalCode(ev, args);
 
         } catch (err) {
             var asErr = 'AfterSave error: ' + dSession.utils.errMsg(err);
@@ -1871,10 +1873,10 @@ function getEvent(pEvent) {
 }
 
 // evalCode con context root
-async function evalCode(code) {
+async function evalCode(code, args) {
     var pipe = {};
-    eval(`pipe.fn = async () => {\n\n${code}\n};`);
-    await pipe.fn();
+    eval(`pipe.fn = async (args) => {\n\n${code}\n};`);
+    await pipe.fn(args);
 }
 
 /*

--- a/app7/generic.js
+++ b/app7/generic.js
@@ -1699,6 +1699,7 @@ async function saveDoc(exitOnSuccess) {
         }
 
         try {
+            debugger;
             // Evento afterSave
             $page[0].dispatchEvent(new CustomEvent('afterSave'));
 
@@ -1871,7 +1872,6 @@ function getEvent(pEvent) {
 
 // evalCode con context root
 async function evalCode(code) {
-    debugger;
     var pipe = {};
     eval(`pipe.fn = async () => {\n\n${code}\n};`);
     await pipe.fn();

--- a/app7/generic.js
+++ b/app7/generic.js
@@ -1871,6 +1871,7 @@ function getEvent(pEvent) {
 
 // evalCode con context root
 async function evalCode(code) {
+    debugger;
     var pipe = {};
     eval(`pipe.fn = async () => {\n\n${code}\n};`);
     await pipe.fn();

--- a/app7/generic.js
+++ b/app7/generic.js
@@ -1675,9 +1675,11 @@ async function saveDoc(exitOnSuccess) {
     });
 
     try {
-        var args = {"exitOnSuccess": exitOnSuccess};
+        //Parametros para disponibilizar en los eventos
+        var args = { "exitOnSuccess" : exitOnSuccess };
+
         // Evento beforeSave
-        $page[0].dispatchEvent(new CustomEvent('beforeSave'));
+        $page[0].dispatchEvent(new CustomEvent('beforeSave', { detail : args }));
 
         // Control Event BeforeSave
         var ev = getEvent('BeforeSave');
@@ -1700,9 +1702,8 @@ async function saveDoc(exitOnSuccess) {
         }
 
         try {
-            debugger;
             // Evento afterSave
-            $page[0].dispatchEvent(new CustomEvent('afterSave'));
+            $page[0].dispatchEvent(new CustomEvent('afterSave', { detail : args }));
 
             // Control Event AfterSave
             var ev = getEvent('AfterSave');

--- a/app7/generic.js
+++ b/app7/generic.js
@@ -1675,8 +1675,7 @@ async function saveDoc(exitOnSuccess) {
     });
 
     try {
-        var args = [];
-        args.push(exitOnSuccess);
+        var args = {"exitOnSuccess": exitOnSuccess};
         // Evento beforeSave
         $page[0].dispatchEvent(new CustomEvent('beforeSave'));
 
@@ -1875,7 +1874,7 @@ function getEvent(pEvent) {
 // evalCode con context root
 async function evalCode(code, args) {
     var pipe = {};
-    eval(`pipe.fn = async (args) => {\n\n${code}\n};`);
+    eval(`pipe.fn = async () => {\n\n${code}\n};`);
     await pipe.fn(args);
 }
 


### PR DESCRIPTION
La idea es poder contar en principio con la variable exitOnSuccess, manana pueden ser alguna mas, en los controles AfterSave y BeforeSave y los eventos de page  beforeSave y afterSave.

Para poder identificar si se queda o se va del generic despues de guardar.

Esto estaba disponible antes de que EvalCode sea async via el pipe para soportar codigo async.

Desde los controles se accederia mediante  args.exitOnSuccess

Desde los eventos se accederia mediante ev.detail.exitOnSuccess
![image](https://user-images.githubusercontent.com/11545485/234663683-834b749d-72cc-415b-b723-a7eb50066c39.png)


